### PR TITLE
Fix hardcoded www-path for CRON

### DIFF
--- a/docker-ilias-entrypoint
+++ b/docker-ilias-entrypoint
@@ -136,7 +136,7 @@ upload_max_filesize = ${ILIAS_MAX_UPLOAD_SIZE}
 post_max_size = ${ILIAS_MAX_UPLOAD_SIZE}
 "
 CRON="
-*/10 * * * * root su www-data -s /bin/sh -c \"/usr/local/bin/php /var/www/html/cron/cron.php root ${ILIAS_ROOT_PASSWORD} ${ILIAS_CLIENT_NAME}\" 1>/proc/1/fd/1 2>/proc/1/fd/2
+*/10 * * * * root su www-data -s /bin/sh -c \"/usr/local/bin/php ${ILIAS_WWW_PATH}/cron/cron.php root ${ILIAS_ROOT_PASSWORD} ${ILIAS_CLIENT_NAME}\" 1>/proc/1/fd/1 2>/proc/1/fd/2
 "
 
 echo "${PHP_INI}" > ${PHP_INI_DIR}/conf.d/ilias.ini

--- a/docker-ilias-entrypoint-setup-cli
+++ b/docker-ilias-entrypoint-setup-cli
@@ -138,7 +138,7 @@ upload_max_filesize = ${ILIAS_MAX_UPLOAD_SIZE}
 post_max_size = ${ILIAS_MAX_UPLOAD_SIZE}
 "
 CRON="
-*/10 * * * * root su www-data -s /bin/sh -c \"/usr/local/bin/php /var/www/html/cron/cron.php root ${ILIAS_ROOT_PASSWORD} ${ILIAS_CLIENT_NAME}\" 1>/proc/1/fd/1 2>/proc/1/fd/2
+*/10 * * * * root su www-data -s /bin/sh -c \"/usr/local/bin/php ${ILIAS_WWW_PATH}/cron/cron.php root ${ILIAS_ROOT_PASSWORD} ${ILIAS_CLIENT_NAME}\" 1>/proc/1/fd/1 2>/proc/1/fd/2
 "
 INSTALL_JSON="
 {


### PR DESCRIPTION
Hello, 
we noticed while configuring ILIAS_WWW_PATH, that cron was not working and found a hardcoded path to the cron.php.